### PR TITLE
Add basic hand-tracking to fire particle example

### DIFF
--- a/godot_examples/particle2D_fire/Fire.gd
+++ b/godot_examples/particle2D_fire/Fire.gd
@@ -3,6 +3,8 @@ extends Node2D
 
 var dev = gdMprDevice.new()
 var radius = 2.0
+# This radius scale is to be used when connecting to various libmapper devices! TODO: Consider scaling on the other side of the libmapper map.
+export var radius_scale = 200
 
 func _ready():
 	dev.init("fire")
@@ -12,5 +14,5 @@ func _ready():
 
 func _process(delta):
 	dev.poll()
-	radius = dev.get_value_float("radius")
+	radius = dev.get_value_float("radius") * radius_scale
 	$Flame.process_material.set_emission_sphere_radius(radius)

--- a/godot_examples/particle2D_fire/README.md
+++ b/godot_examples/particle2D_fire/README.md
@@ -1,0 +1,25 @@
+# Particle Fire Example
+
+This example uses a libmapper device to control the radius of a 2d particle fire effect in Godot.
+
+## Slider
+
+To use with hand-tracking, first you need to run the Godot scene and then:
+
+```bash
+./tkgui.py
+
+# Connect via libmapper
+./umapper -M tkgui.1/output fire.1/radius
+```
+
+## Hand-tracking
+
+To use with hand-tracking, first you need to run the Godot scene and then:
+
+```bash
+./mediapipe-tracker.py
+
+# Connect via libmapper
+./umapper -M hand_tracker.1/index-thumb-distance fire.1/radius
+```

--- a/godot_examples/particle2D_fire/mediapipe-tracker.py
+++ b/godot_examples/particle2D_fire/mediapipe-tracker.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+
+import cv2
+import mediapipe as mp
+import mapper as mpr
+mp_drawing = mp.solutions.drawing_utils
+mp_hands = mp.solutions.hands
+
+
+hand_dev = mpr.device("hand_tracker")
+
+dist = hand_dev.add_signal(mpr.DIR_OUT, "index-thumb-distance", 1,
+                           mpr.FLT, None, None, None)
+
+# Begin webcam input for hand tracking:
+hands = mp_hands.Hands(min_detection_confidence=0.7,
+                       min_tracking_confidence=0.5)
+
+cap = cv2.VideoCapture(0)
+
+width = cap.get(cv2.CAP_PROP_FRAME_WIDTH)
+height = cap.get(cv2.CAP_PROP_FRAME_HEIGHT)
+
+print(width, height)
+
+while(not hand_dev.get_is_ready()):
+    hand_dev.poll(25)
+
+print("Libmapper Dev Ready!")
+
+while cap.isOpened():
+    success, image = cap.read()
+    if not success:
+        break
+
+    # Poll the mediapipe devices to ensure that the signals are being updated properly
+    hand_dev.poll()
+
+    # Flip the image horizontally for a later selfie-view display, and convert
+    # the BGR image to RGB.
+    image = cv2.cvtColor(cv2.flip(image, 1), cv2.COLOR_BGR2RGB)
+
+    # To improve performance, optionally mark the image as not writeable to
+    # pass by reference.
+    image.flags.writeable = False
+    results = hands.process(image)
+
+    # Draw the hand annotations on the image.
+    image.flags.writeable = True
+    image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
+
+    if results.multi_hand_landmarks:
+        # Update the libmapper devices with landmark data
+        for hand_landmarks in results.multi_hand_landmarks:
+
+            # Compute distance between thumb-tip and index-tip
+            distance = math.abs(math.hypot(
+                hand_landmarks.landmark[8].x - hand_landmarks.landmark[4].x, hand_landmarks.landmark[8].y - hand_landmarks.landmark[4].y))
+
+            # Update signal with value calculated above
+            dist.set_value(distance)
+
+            # Draw skeletal structure over video
+            mp_drawing.draw_landmarks(
+                image, hand_landmarks, mp_hands.HAND_CONNECTIONS)
+
+    cv2.imshow('MediaPipe Hands', image)
+
+    if cv2.waitKey(5) & 0xFF == 27:
+        break
+
+hands.close()
+cap.release()

--- a/godot_examples/particle2D_fire/mediapipe-tracker.py
+++ b/godot_examples/particle2D_fire/mediapipe-tracker.py
@@ -3,6 +3,8 @@
 import cv2
 import mediapipe as mp
 import mapper as mpr
+import math
+
 mp_drawing = mp.solutions.drawing_utils
 mp_hands = mp.solutions.hands
 
@@ -54,7 +56,7 @@ while cap.isOpened():
         for hand_landmarks in results.multi_hand_landmarks:
 
             # Compute distance between thumb-tip and index-tip
-            distance = math.abs(math.hypot(
+            distance = abs(math.hypot(
                 hand_landmarks.landmark[8].x - hand_landmarks.landmark[4].x, hand_landmarks.landmark[8].y - hand_landmarks.landmark[4].y))
 
             # Update signal with value calculated above


### PR DESCRIPTION
This PR adds basic hand-tracking to the 2d fire particle example. The libmapper signal reports the distance between the index-tip and thumb-tip and the godot scene consumes that value to adjust the radius of the particle effect.

See `README.md` for instructions on running.